### PR TITLE
Add support for capture element

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ HTML:
     ng-file-change="fileSelected($files, $event)" // will be called upon files being selected
                                                   // you can use $scope.$watch('myFiles') instead
     ng-multiple="true|false" // default false, allows selecting multiple files
+    ng-capture="'camera'|'other'" // default not included, allows mobile devices to capture using camera
     accept="image/*,*.pdf,*.xml" // see standard HTML file input accept attribute
     resetOnClick="true|false" // default true, reset the value to null and clear selected files when
                               // user cancels file select popup. (default behaviour in Chrome)

--- a/dist/angular-file-upload.js
+++ b/dist/angular-file-upload.js
@@ -170,7 +170,8 @@ angularFileUpload.directive('ngFileSelect', [ '$parse', '$timeout', function($pa
 		select : '&ngFileSelect',
 		resetOnClick: '&resetOnClick',
 		multiple: '&ngMultiple',
-		accept: '&ngAccept'
+		accept: '&ngAccept',
+		capture: '&ngCapture'
 	},
 	link: function(scope, elem, attr, ngModel) {
 		handleFileSelect(scope, elem, attr, ngModel, $parse, $timeout);
@@ -191,6 +192,7 @@ function handleFileSelect(scope, elem, attr, ngModel, $parse, $timeout) {
 		var fileElem = angular.element('<input type="file">')
 		if (attr['multiple']) fileElem.attr('multiple', attr['multiple']);
 		if (attr['accept']) fileElem.attr('accept', attr['accept']);
+		if (attr['capture']) fileElem.attr('capture', attr['capture']);
 		fileElem.css('width', '1px').css('height', '1px').css('opacity', 0).css('position', 'absolute').css('filter', 'alpha(opacity=0)')
 				.css('padding', 0).css('margin', 0).css('overflow', 'hidden').attr('tabindex', '-1').attr('ng-file-generated-elem', true);
 		elem.append(fileElem);

--- a/dist/angular-file-upload.js
+++ b/dist/angular-file-upload.js
@@ -188,6 +188,11 @@ function handleFileSelect(scope, elem, attr, ngModel, $parse, $timeout) {
 		elem.attr('accept', accept);
 		attr['accept'] = accept;
 	}
+	var capture = scope.capture();
+	if (capture) {
+		elem.attr('capture', capture);
+		attr['capture'] = capture;
+	}
 	if (elem[0].tagName.toLowerCase() !== 'input' || (elem.attr('type') && elem.attr('type').toLowerCase()) !== 'file') {
 		var fileElem = angular.element('<input type="file">')
 		if (attr['multiple']) fileElem.attr('multiple', attr['multiple']);


### PR DESCRIPTION
Those of use using this on mobile devices could quite benefit from the `capture` attribute, as many times we want to have separate buttons for "choose a photo" and "take a photo". Also `capture` supports audio and video on some devices (though I'm not sure which).

This just adds support to the input element as it doesn't make much sense for drop targets.